### PR TITLE
parameterize package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.kenshoo:gradle-fpm:0.4'
+        classpath 'com.kenshoo:gradle-fpm:0.5'
     }
 }
 
@@ -21,6 +21,7 @@ apply plugin: 'fpm-packaging'
 
 //to create deb package
 packaging {
+    packageName = 'my-package' // Optional, default is project.name
     dependencies = ['openjdk-6-jre', 'tomcat7'] //Optional, an array of package dependencies
     baseDir = project.buildDir// Optional, base directory to package, default: project.buildDir
     prefix = /opt/my-process // Optional, a path to prefix files when building package, default: root (/)

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'idea'
 apply plugin: 'signing'
 
 group = 'com.kenshoo'
-version = '0.4'
+version = '0.5'
 
 dependencies {
     compile gradleApi()

--- a/src/main/groovy/com/kenshoo/watership/PackagingPluginExtension.groovy
+++ b/src/main/groovy/com/kenshoo/watership/PackagingPluginExtension.groovy
@@ -21,6 +21,9 @@ import org.gradle.api.tasks.OutputDirectory
 
 class PackagingPluginExtension {
     @Input
+    def packageName
+
+    @Input
     def dependencies = []
 
     @Input

--- a/src/main/groovy/com/kenshoo/watership/PackagingTask.groovy
+++ b/src/main/groovy/com/kenshoo/watership/PackagingTask.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.TaskAction
 
 abstract class PackagingTask extends DefaultTask {
     def FPM = "fpm"
+    def packageName
     def dependencies
     def prefix
     def type
@@ -53,7 +54,7 @@ abstract class PackagingTask extends DefaultTask {
 
     def getArgs() {
         def version = project.version
-        def fpmArgs = ["-t", type, "-s", "dir", "-n", "${project.name}", "-v", "$version","-C", baseDir]
+        def fpmArgs = ["-t", type, "-s", "dir", "-n", packageName, "-v", "$version","-C", baseDir]
         if (prefix)
             fpmArgs.addAll(["--prefix", prefix])
         dependencies.each() {
@@ -91,6 +92,7 @@ abstract class PackagingTask extends DefaultTask {
     }
 
     def initConfiguration() {
+        packageName = project.packaging.packageName ? project.packaging.packageName : project.name
         dependencies = project.packaging.dependencies
         prefix = project.packaging.prefix
         filesArgs = project.packaging.filesArgs ? project.packaging.filesArgs : "."


### PR DESCRIPTION
@liorhar can be useful when the project name isn't appropriate as a package name  